### PR TITLE
Additional condition in loadplayer() for netease 1.29.1

### DIFF
--- a/parser/w3g-julas.php
+++ b/parser/w3g-julas.php
@@ -187,7 +187,9 @@ class replay
             $this->data = substr($this->data, 8);
             $this->players[$player_id]['exe_runtime'] = $temp['runtime'];
             $this->players[$player_id]['race'] = convert_race($temp['race']);
-        }
+        } else if (ord($this->data{0}) == 2) { // necessary since netease 1.29.1
+			$this->data = substr($this->data, 3);
+		}
         if ($this->parse_actions) {
             $this->players[$player_id]['actions'] = 0;
         }


### PR DESCRIPTION
In netease 1.29.1 there was a change regarding the observers which
requires an additional condition that skips 3 bytes if the game was
saved by a live observer